### PR TITLE
CRUD-Operations on products and catalogs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        {
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/bin/Debug/netcoreapp2.1/graphql-showcase.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "^\\s*Now listening on:\\s+(https?://\\S+)"
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet build",
+            "type": "shell",
+            "group": "build",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/API/Resolvers/MutationResolver.cs
+++ b/API/Resolvers/MutationResolver.cs
@@ -14,5 +14,11 @@ namespace graphql_showcase.API.Resolvers
         {
             return await repository.CreateProduct(input.ProductName, input.GTIN);
         }
+
+        public async Task<Domain.Product> DeleteProduct([GraphQLNonNullType] Guid id,
+                                                        [Service] Domain.DataAccess.IProductRepository repository)
+        {
+            return await repository.DeleteProduct(id);
+        }
     }
 }

--- a/API/Resolvers/MutationResolver.cs
+++ b/API/Resolvers/MutationResolver.cs
@@ -1,7 +1,5 @@
 ﻿using HotChocolate;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace graphql_showcase.API.Resolvers
@@ -15,10 +13,18 @@ namespace graphql_showcase.API.Resolvers
             return await repository.CreateProduct(input.ProductName, input.GTIN);
         }
 
+        [GraphQLDescription("Delete a product")]
         public async Task<Domain.Product> DeleteProduct([GraphQLNonNullType] Guid id,
                                                         [Service] Domain.DataAccess.IProductRepository repository)
         {
             return await repository.DeleteProduct(id);
+        }
+
+        public async Task<Domain.Product> UpdateProduct([GraphQLNonNullType] Guid id,
+                                                        [GraphQLNonNullType] Types.UpdateProductInput input,
+                                                        [Service] Domain.DataAccess.IProductRepository repository)
+        {
+            return await repository.UpdateProduct(id, input.Name, input.GTIN);
         }
     }
 }

--- a/API/Resolvers/MutationResolver.cs
+++ b/API/Resolvers/MutationResolver.cs
@@ -38,5 +38,12 @@ namespace graphql_showcase.API.Resolvers
         {
             return await repository.DeleteCatalog(id);
         }
+
+        public async Task<Domain.Catalog> UpdateCatalog([GraphQLNonNullType] Guid id,
+                                                        [GraphQLNonNullType] Types.UpdateCatalogInput input,
+                                                        [Service] Domain.DataAccess.ICatalogRepository repository)
+        {
+            return await repository.UpdateCatalog(id, input.Name);
+        }
     }
 }

--- a/API/Resolvers/MutationResolver.cs
+++ b/API/Resolvers/MutationResolver.cs
@@ -28,8 +28,15 @@ namespace graphql_showcase.API.Resolvers
         }
 
         public async Task<Domain.Catalog> CreateCatalog([GraphQLNonNullType] Types.CreateCatalogInput input,
-                                                        [Service] Domain.DataAccess.ICatalogRepository repository){
+                                                        [Service] Domain.DataAccess.ICatalogRepository repository)
+        {
             return await repository.CreateCatalog(input.CatalogName);
+        }
+
+        public async Task<Domain.Catalog> DeleteCatalog([GraphQLNonNullType] Guid id,
+                                                        [Service] Domain.DataAccess.ICatalogRepository repository)
+        {
+            return await repository.DeleteCatalog(id);
         }
     }
 }

--- a/API/Resolvers/MutationResolver.cs
+++ b/API/Resolvers/MutationResolver.cs
@@ -26,5 +26,10 @@ namespace graphql_showcase.API.Resolvers
         {
             return await repository.UpdateProduct(id, input.Name, input.GTIN);
         }
+
+        public async Task<Domain.Catalog> CreateCatalog([GraphQLNonNullType] Types.CreateCatalogInput input,
+                                                        [Service] Domain.DataAccess.ICatalogRepository repository){
+            return await repository.CreateCatalog(input.CatalogName);
+        }
     }
 }

--- a/API/Resolvers/MutationResolver.cs
+++ b/API/Resolvers/MutationResolver.cs
@@ -1,0 +1,18 @@
+﻿using HotChocolate;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace graphql_showcase.API.Resolvers
+{
+    public class MutationResolver
+    {
+        [GraphQLDescription("Create a new product")]
+        public async Task<Domain.Product> CreateProduct([GraphQLNonNullType] Types.CreateProductInput input,
+                                                        [Service] Domain.DataAccess.IProductRepository repository)
+        {
+            return await repository.CreateProduct(input.ProductName, input.GTIN);
+        }
+    }
+}

--- a/API/Types/CreateCatalogInputType.cs
+++ b/API/Types/CreateCatalogInputType.cs
@@ -1,0 +1,21 @@
+using HotChocolate;
+using HotChocolate.Types;
+
+namespace graphql_showcase.API.Types
+{
+    public class CreateCatalogInput
+    {
+        [GraphQLName("name")]
+        [GraphQLDescription("the name of the new catalog")]
+        [GraphQLNonNullType]
+        public string CatalogName { get; set; }
+    }
+
+    public class CreateCatalogInputType : InputObjectType<CreateCatalogInput>
+    {
+        protected override void Configure(IInputObjectTypeDescriptor<CreateCatalogInput> descriptor)
+        {
+            descriptor.Name("CreateCatalogInput");
+        }
+    }
+}

--- a/API/Types/CreateProductInputType.cs
+++ b/API/Types/CreateProductInputType.cs
@@ -1,0 +1,26 @@
+﻿using HotChocolate;
+using HotChocolate.Types;
+
+namespace graphql_showcase.API.Types
+{
+    public class CreateProductInput
+    {
+        [GraphQLName("name")]
+        [GraphQLDescription("the name of the new product")]
+        [GraphQLNonNullType]
+        public string ProductName { get; set; }
+
+        [GraphQLName("GTIN")]
+        [GraphQLDescription("the global trade item number of the new product")]
+        [GraphQLNonNullType]
+        public long GTIN { get; set; }
+    }
+
+    public class CreateProductInputType : InputObjectType<CreateProductInput>
+    {
+        protected override void Configure(IInputObjectTypeDescriptor<CreateProductInput> descriptor)
+        {
+            descriptor.Name("CreateProductInput");
+        }
+    }
+}

--- a/API/Types/MutationType.cs
+++ b/API/Types/MutationType.cs
@@ -1,0 +1,17 @@
+﻿using graphql_showcase.API.Resolvers;
+using HotChocolate.Types;
+
+namespace graphql_showcase.API.Types
+{
+    public class Mutation { }
+
+    public class MutationType : ObjectType<Mutation>
+    {
+        protected override void Configure(IObjectTypeDescriptor<Mutation> descriptor)
+        {
+            descriptor.Name("Mutation");
+            descriptor.BindFields(BindingBehavior.Explicit);
+            descriptor.Include<MutationResolver>();
+        }
+    }
+}

--- a/API/Types/QueryType.cs
+++ b/API/Types/QueryType.cs
@@ -1,6 +1,6 @@
 ﻿using HotChocolate.Types;
 
-namespace graphql_showcase
+namespace graphql_showcase.API.Types
 {
     public class Query
     {
@@ -14,7 +14,7 @@ namespace graphql_showcase
             descriptor.Description("Provides access to queries");
 
             descriptor.BindFields(BindingBehavior.Explicit);
-            descriptor.Include<API.Resolvers.QueryResolver>();
+            descriptor.Include<Resolvers.QueryResolver>();
         }
     }
 }

--- a/API/Types/UpdateCatalogInputType.cs
+++ b/API/Types/UpdateCatalogInputType.cs
@@ -1,0 +1,20 @@
+using HotChocolate;
+using HotChocolate.Types;
+
+namespace graphql_showcase.API.Types
+{
+    public class UpdateCatalogInput
+    {
+        [GraphQLNonNullType]
+        [GraphQLDescription("the new name of the catalog")]
+        public string Name { get; set; }
+    }
+
+    public class UpdateCatalogInputType : InputObjectType<UpdateCatalogInput>
+    {
+        protected override void Configure(IInputObjectTypeDescriptor<UpdateCatalogInput> descriptor)
+        {
+            descriptor.Name("UpdateCatalogInput");
+        }
+    }
+}

--- a/API/Types/UpdateProductInputType.cs
+++ b/API/Types/UpdateProductInputType.cs
@@ -1,0 +1,25 @@
+﻿using HotChocolate;
+using HotChocolate.Types;
+
+namespace graphql_showcase.API.Types
+{
+    public class UpdateProductInput
+    {
+        [GraphQLNonNullType]
+        [GraphQLDescription("the new name of the product")]
+        public string Name { get; set; }
+
+        [GraphQLName("GTIN")]
+        [GraphQLNonNullType]
+        [GraphQLDescription("the new global trade item number of the product")]
+        public long GTIN { get; set; }
+    }
+
+    public class UpdateProductInputType : InputObjectType<UpdateProductInput>
+    {
+        protected override void Configure(IInputObjectTypeDescriptor<UpdateProductInput> descriptor)
+        {
+            descriptor.Name("UpdateProductInput");
+        }
+    }
+}

--- a/Domain/DataAccess/ICatalogRepository.cs
+++ b/Domain/DataAccess/ICatalogRepository.cs
@@ -9,6 +9,8 @@ namespace graphql_showcase.Domain.DataAccess
     {
         Task<Catalog> GetCatalogById(Guid id);
         Task<IEnumerable<Catalog>> GetAllCatalogs();
+
+        Task<Catalog> CreateCatalog(string name);
     }
 
     public class InMemoryCatalogRepository : ICatalogRepository
@@ -24,6 +26,19 @@ namespace graphql_showcase.Domain.DataAccess
         public async Task<Catalog> GetCatalogById(Guid id)
         {
             return Catalogs.Single(catalog => catalog.ID == id);
+        }
+
+        public async Task<Catalog> CreateCatalog(string name)
+        {
+            var newCatalog = new Catalog()
+            {
+                ID = Guid.NewGuid(),
+                Name = name
+            };
+
+            Catalogs.Add(newCatalog);
+
+            return newCatalog;
         }
     }
 }

--- a/Domain/DataAccess/ICatalogRepository.cs
+++ b/Domain/DataAccess/ICatalogRepository.cs
@@ -11,6 +11,8 @@ namespace graphql_showcase.Domain.DataAccess
         Task<IEnumerable<Catalog>> GetAllCatalogs();
 
         Task<Catalog> CreateCatalog(string name);
+
+        Task<Catalog> DeleteCatalog(Guid id);
     }
 
     public class InMemoryCatalogRepository : ICatalogRepository
@@ -39,6 +41,13 @@ namespace graphql_showcase.Domain.DataAccess
             Catalogs.Add(newCatalog);
 
             return newCatalog;
+        }
+
+        public async Task<Catalog> DeleteCatalog(Guid id)
+        {
+            var catalogToDelete = Catalogs.Single(catalog => catalog.ID == id);
+            Catalogs.Remove(catalogToDelete);
+            return catalogToDelete;
         }
     }
 }

--- a/Domain/DataAccess/ICatalogRepository.cs
+++ b/Domain/DataAccess/ICatalogRepository.cs
@@ -13,6 +13,8 @@ namespace graphql_showcase.Domain.DataAccess
         Task<Catalog> CreateCatalog(string name);
 
         Task<Catalog> DeleteCatalog(Guid id);
+
+        Task<Catalog> UpdateCatalog(Guid id, string name);
     }
 
     public class InMemoryCatalogRepository : ICatalogRepository
@@ -48,6 +50,13 @@ namespace graphql_showcase.Domain.DataAccess
             var catalogToDelete = Catalogs.Single(catalog => catalog.ID == id);
             Catalogs.Remove(catalogToDelete);
             return catalogToDelete;
+        }
+
+        public async Task<Catalog> UpdateCatalog(Guid id, string name)
+        {
+            var catalogToChange = Catalogs.Single(catalog => catalog.ID == id);
+            catalogToChange.Name = name;
+            return catalogToChange;
         }
     }
 }

--- a/Domain/DataAccess/IProductRepository.cs
+++ b/Domain/DataAccess/IProductRepository.cs
@@ -14,6 +14,8 @@ namespace graphql_showcase.Domain.DataAccess
 
         Task<Product> CreateProduct(string name, long gtin);
 
+        Task<Product> UpdateProduct(Guid id, string name, long gtin);
+
         Task<Product> DeleteProduct(Guid id);
     }
 
@@ -56,6 +58,16 @@ namespace graphql_showcase.Domain.DataAccess
             Products.Remove(productToDelete);
 
             return productToDelete;
+        }
+
+        public async Task<Product> UpdateProduct(Guid id, string name, long gtin)
+        {
+            var productToUpdate = Products.Single(product => product.ID == id);
+
+            productToUpdate.Name = name;
+            productToUpdate.GTIN = gtin;
+
+            return productToUpdate;
         }
     }
 }

--- a/Domain/DataAccess/IProductRepository.cs
+++ b/Domain/DataAccess/IProductRepository.cs
@@ -13,6 +13,8 @@ namespace graphql_showcase.Domain.DataAccess
         Task<IEnumerable<Product>> GetAllProducts();
 
         Task<Product> CreateProduct(string name, long gtin);
+
+        Task<Product> DeleteProduct(Guid id);
     }
 
     public class InMemoryProductRepository : IProductRepository
@@ -45,6 +47,15 @@ namespace graphql_showcase.Domain.DataAccess
             Products.Add(newProduct);
 
             return newProduct;
+        }
+
+        public async Task<Product> DeleteProduct(Guid id)
+        {
+            var productToDelete = Products.Single(product => product.ID == id);
+
+            Products.Remove(productToDelete);
+
+            return productToDelete;
         }
     }
 }

--- a/Domain/DataAccess/IProductRepository.cs
+++ b/Domain/DataAccess/IProductRepository.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using graphql_showcase.API.Types;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,6 +11,8 @@ namespace graphql_showcase.Domain.DataAccess
         Task<Product> GetProductById(Guid id);
 
         Task<IEnumerable<Product>> GetAllProducts();
+
+        Task<Product> CreateProduct(string name, long gtin);
     }
 
     public class InMemoryProductRepository : IProductRepository
@@ -28,6 +31,20 @@ namespace graphql_showcase.Domain.DataAccess
         public async Task<Product> GetProductById(Guid id)
         {
             return Products.Single(product => product.ID == id);
+        }
+
+        public async Task<Product> CreateProduct(string name, long gtin)
+        {
+            var newProduct = new Product()
+            {
+                ID = Guid.NewGuid(),
+                Name = name ?? throw new ArgumentNullException(nameof(name)),
+                GTIN = gtin
+            };
+
+            Products.Add(newProduct);
+
+            return newProduct;
         }
     }
 }

--- a/Startup.cs
+++ b/Startup.cs
@@ -26,10 +26,13 @@ namespace graphql_showcase
                 // enable for authorization support
                 // .AddDirectiveType<AuthorizeDirectiveType>()
 
-                .AddQueryType<QueryType>()
+                .AddQueryType<API.Types.QueryType>()
+                .AddMutationType<API.Types.MutationType>()
 
                 .AddType<API.Types.ProductType>()
                 .AddType<API.Types.CatalogType>()
+
+                .AddType<API.Types.CreateProductInputType>()
 
                 .Create());
         }

--- a/Startup.cs
+++ b/Startup.cs
@@ -35,6 +35,7 @@ namespace graphql_showcase
 
                 .AddType<API.Types.CatalogType>()
                 .AddType<API.Types.CreateCatalogInputType>()
+                .AddType<API.Types.UpdateCatalogInputType>()
 
                 .Create());
         }

--- a/Startup.cs
+++ b/Startup.cs
@@ -34,6 +34,7 @@ namespace graphql_showcase
                 .AddType<API.Types.UpdateProductInputType>()
 
                 .AddType<API.Types.CatalogType>()
+                .AddType<API.Types.CreateCatalogInputType>()
 
                 .Create());
         }

--- a/Startup.cs
+++ b/Startup.cs
@@ -30,9 +30,10 @@ namespace graphql_showcase
                 .AddMutationType<API.Types.MutationType>()
 
                 .AddType<API.Types.ProductType>()
-                .AddType<API.Types.CatalogType>()
-
                 .AddType<API.Types.CreateProductInputType>()
+                .AddType<API.Types.UpdateProductInputType>()
+
+                .AddType<API.Types.CatalogType>()
 
                 .Create());
         }


### PR DESCRIPTION
This adds support for manipulating products and catalogs. Currently there is no persistence, so in order to test these manipulations, you'd have to go through the whole lifecycle of the entities (i.e. create a product, then change or delete a product after getting its ID).

There is no implementation of events yet, so only the user that initiates the request will get the info about the new entities.

There is also no way of adding products to catalogs so far. So the product and catalog entities live a pretty lonely life.

Fixes #1 