### PR TITLE
Making catalogs named collections of products

### DIFF
--- a/API/Resolvers/CatalogResolver.cs
+++ b/API/Resolvers/CatalogResolver.cs
@@ -1,6 +1,9 @@
 ﻿using HotChocolate;
 using HotChocolate.Types;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace graphql_showcase.API.Resolvers
 {
@@ -18,6 +21,20 @@ namespace graphql_showcase.API.Resolvers
         public string Name([Parent] Domain.Catalog catalog)
         {
             return catalog.Name;
+        }
+
+        public async Task<IList<Domain.Product>> Products([Parent] Domain.Catalog catalog,
+                                                          [Service] Domain.DataAccess.IProductRepository productRepository)
+        {
+            var products = new List<Domain.Product>();
+
+            foreach (var productID in catalog.Products)
+            {
+                var referencedProduct = await productRepository.GetProductById(productID);
+                products.Add(referencedProduct);
+            }
+
+            return products;
         }
     }
 }

--- a/API/Resolvers/MutationResolver.cs
+++ b/API/Resolvers/MutationResolver.cs
@@ -61,5 +61,21 @@ namespace graphql_showcase.API.Resolvers
                 return referencedCatalog;
             }
         }
+
+        public async Task<Domain.Catalog> RemoveProductFromCatalog([GraphQLNonNullType] Guid catalogID,
+                                                                   [GraphQLNonNullType] Guid productID,
+                                                                   [Service] Domain.DataAccess.ICatalogRepository catalogRepository)
+        {
+            var referencedCatalog = await catalogRepository.GetCatalogById(catalogID);
+
+            if (referencedCatalog.Products.Contains(productID))
+            {
+                return await catalogRepository.RemoveProduct(catalogID, productID);
+            }
+            else
+            {
+                return referencedCatalog;
+            }
+        }
     }
 }

--- a/API/Resolvers/MutationResolver.cs
+++ b/API/Resolvers/MutationResolver.cs
@@ -45,5 +45,21 @@ namespace graphql_showcase.API.Resolvers
         {
             return await repository.UpdateCatalog(id, input.Name);
         }
+
+        public async Task<Domain.Catalog> AddProductToCatalog([GraphQLNonNullType] Guid catalogID,
+                                                              [GraphQLNonNullType] Guid productID,
+                                                              [Service] Domain.DataAccess.ICatalogRepository catalogRepository)
+        {
+            var referencedCatalog = await catalogRepository.GetCatalogById(catalogID);
+
+            if (!referencedCatalog.Products.Contains(productID))
+            {
+                return await catalogRepository.AddProduct(catalogID, productID);
+            }
+            else
+            {
+                return referencedCatalog;
+            }
+        }
     }
 }

--- a/Domain/Catalog.cs
+++ b/Domain/Catalog.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace graphql_showcase.Domain
 {
@@ -6,5 +7,7 @@ namespace graphql_showcase.Domain
     {
         public Guid ID { get; set; }
         public string Name { get; set; }
+
+        public IList<Guid> Products { get; } = new List<Guid>();
     }
 }

--- a/Domain/DataAccess/ICatalogRepository.cs
+++ b/Domain/DataAccess/ICatalogRepository.cs
@@ -15,6 +15,8 @@ namespace graphql_showcase.Domain.DataAccess
         Task<Catalog> DeleteCatalog(Guid id);
 
         Task<Catalog> UpdateCatalog(Guid id, string name);
+
+        Task<Catalog> AddProduct(Guid catalogID, Guid productID);
     }
 
     public class InMemoryCatalogRepository : ICatalogRepository
@@ -57,6 +59,15 @@ namespace graphql_showcase.Domain.DataAccess
             var catalogToChange = Catalogs.Single(catalog => catalog.ID == id);
             catalogToChange.Name = name;
             return catalogToChange;
+        }
+
+        public async Task<Catalog> AddProduct(Guid catalogID, Guid productID)
+        {
+            var referencedCatalog = Catalogs.Single(catalog => catalog.ID == catalogID);
+
+            referencedCatalog.Products.Add(productID);
+
+            return referencedCatalog;
         }
     }
 }

--- a/Domain/DataAccess/ICatalogRepository.cs
+++ b/Domain/DataAccess/ICatalogRepository.cs
@@ -17,6 +17,8 @@ namespace graphql_showcase.Domain.DataAccess
         Task<Catalog> UpdateCatalog(Guid id, string name);
 
         Task<Catalog> AddProduct(Guid catalogID, Guid productID);
+
+        Task<Catalog> RemoveProduct(Guid catalogID, Guid productID);
     }
 
     public class InMemoryCatalogRepository : ICatalogRepository
@@ -66,6 +68,15 @@ namespace graphql_showcase.Domain.DataAccess
             var referencedCatalog = Catalogs.Single(catalog => catalog.ID == catalogID);
 
             referencedCatalog.Products.Add(productID);
+
+            return referencedCatalog;
+        }
+
+        public async Task<Catalog> RemoveProduct(Guid catalogID, Guid productID)
+        {
+            var referencedCatalog = Catalogs.Single(catalog => catalog.ID == catalogID);
+
+            referencedCatalog.Products.Remove(productID);
 
             return referencedCatalog;
         }


### PR DESCRIPTION
This PR adds an API for adding and removing products to/from catalogs.

graphiql (available in the Debug build at `${host:port}/graphiql`) can be used to play around with the API. The following snippet might be helpful
```
query allCatalogs {
  catalogs {
    ...catalogRef
  }
}

query allProducts {
  products {
    id
    name
  }
}

mutation newCatalog {
  createCatalog(input: {name: "Peter"}) {
    ...catalogRef
  }
}

mutation deleteCatalog {
  deleteCatalog(id: "36faacbcbab94289a6ec1bd5dce7048d") {
    ...catalogRef
  }
}

mutation updateCatalogName {
  updateCatalog(id: "f2b04f16f0414fdb9500735a7c42ab4d", input: {name: "Steve"}) {
    ...catalogRef
  }
}

mutation newProduct {
  createProduct(input: {name: "8up!", GTIN: 42}) {
    id
    name
  }
}

mutation addProductToCatalog {
  addProductToCatalog(catalogID: "f2b04f16f0414fdb9500735a7c42ab4d", productID: "9101a575963b498f82ca0d01d938ebc8") {
    id
    name
    products {
      name
    }
  }
}

mutation removeProductFromCatalog {
  removeProductFromCatalog(catalogID: "9c67a6660eec459e810ba5398cb5adef", productID: "9101a575963b498f82ca0d01d938ebc8") {
    ...catalogRef
  }
}

fragment catalogRef on Catalog {
  id
  name
  products {
    ...productRef
  }
}

fragment productRef on Product {
  id
  name
  GTIN
}

```

Fixes #4 